### PR TITLE
[FEAT] 공유앨범 버튼 위치 수정

### DIFF
--- a/src/components/sharedAlbum/SharedAlbum.jsx
+++ b/src/components/sharedAlbum/SharedAlbum.jsx
@@ -66,7 +66,7 @@ export default function SharedAlbum() {
   };
 
   return (
-    <div>
+    <div style={{ position: "relative" }}>
       {/* 숨겨진 파일 입력 요소 */}
       <input
         type="file"
@@ -79,12 +79,12 @@ export default function SharedAlbum() {
       <AlbumPhotos picUrls={photoList} start={1} end={photoList.length} />
       <MdDownloadForOffline
         onClick={handleDownloadButtonClick}
-        className={`fixed bottom-20 right-5 z-50`}
+        className={`absolute bottom-20 right-5 z-50`}
         style={{ width: "44px", height: "44px", color: "#9E9C95" }}
       />
       <HiPlusCircle
         onClick={handleUploadButtonClick}
-        className={`fixed bottom-5 right-5 z-50`}
+        className={`absolute bottom-5 right-5 z-50`}
         style={{ width: "44px", height: "44px", color: "#9E9C95" }}
       />
     </div>


### PR DESCRIPTION
공유앨범 탭 업로드, 다운로드 버튼 위치가 viewport에 고정되던 문제 해결했습니다 !